### PR TITLE
Fixed visible runs in Liverpool

### DIFF
--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -5,7 +5,6 @@ from client.ClientState import ClientState
 from client.Controller import Controller
 from client.CreateDisplay import CreateDisplay
 from client.TableView import TableView            # this should support both Liverpool and HandAndFoot
-# from client.TableView_HF import TableView_HF      # this is for HandAndFoot
 from client.HandView import HandView
 # imports below added so that can generate executable using pyinstaller.
 import common.HandAndFoot

--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -67,8 +67,8 @@ def RunClient():
             # Might also need to add visible_cards to playerByPlayer (?)
             # because Liverpool handView needs info on other players (HandAndFoot did not).
             if  ruleset == 'Liverpool':
-                visible_cards = tableView.visible_cards
-                handView.update(player_index, len(tableView.player_names), visible_cards)
+                visible_scards = tableView.visible_scards
+                handView.update(player_index, len(tableView.player_names), visible_scards)
             else:
                 handView.update()
             note = gameControl.note

--- a/source/client/ClientState.py
+++ b/source/client/ClientState.py
@@ -67,18 +67,18 @@ class ClientState:
         self.played_cards = {}
         self.went_out = False
         self.discard_info = [None, 0]
-        
+        self.first_play_this_turn = True
+
     def newCards(self, card_list):
         """Update the cards in hand"""
         for card in card_list:
             self.hand_cards.append(card)
 
-    def playCards(self, prepared_cards, player_index = 0, visible_cards=[{}]):
-        """Move cards from hand to visible"""
+    def playCards(self, prepared_cards, player_index = 0, visible_scards=[{}]):
+        """Move cards from hand to board"""
 
-        # cards in visible_cards are serialized, cards in prepared_cards are not.
         # First check that all the cards are in your hand.
-        print('in ClientState.py, playCards method')
+        visible_cards = [{}]
         tempHand = [x for x in self.hand_cards]
         try:
             for card_group in prepared_cards.values():
@@ -86,9 +86,9 @@ class ClientState:
                     tempHand.remove(card)
         except ValueError:
             raise Exception("Attempted to play cards that are not in your hand")
-        #todo: put variable in rulesets regarding whether you can play on others groups.
-        # for HandAndFoot it would be false, and for Liverpool it would be true.
-        # that would determine whether self.played_cards = visible cards or cards that player played.
+        # Check ruleset to determine whether self.played_cards = visible cards or cards that player played.
+        # todo: Create rule:  Shared_Board == True or False, it would be False for HandAndFoot, Canasta, etc...
+        # but True for Liverpool and other Rummy games.
         if self.ruleset == 'HandAndFoot':
             self.rules.canPlay(prepared_cards, self.played_cards, self.round)
             for key, card_group in prepared_cards.items():
@@ -96,21 +96,33 @@ class ClientState:
                     self.hand_cards.remove(card)
                     self.played_cards.setdefault(key, []).append(card)
         elif self.ruleset == 'Liverpool':
-            self.rules.canPlay(prepared_cards, visible_cards, player_index, self.round)
-            # unlike self.played_cards used in HandAndFoot, visible_cards is obtained
+            # unlike in HandAndFoot, where self.played_cards was used to check rules.
+            # in Liverpool need to consider all of the played cards.
+            # This will be true for all games with Shared_Board == True
+            # Played cards are in visible_scards, which is obtained
             # from controller, and contains serialized cards.
+            # To reduce computations, don't deserialize them until click on play cards button.
+            if self.first_play_this_turn:
+                visible_cards[0] = {key: [scard.deserialize() for scard in scard_group] for (key, scard_group) in
+                                   visible_scards[0].items()}
+                print("visible_cards[0]: ")
+                for key, card in visible_cards[0].items():
+                    print(card)
+                self.first_play_this_turn = False
+            self.played_cards = visible_cards[0]  # in Liverpool all players' cards are included.
+            print("played_cards: ")
+            for key, card in self.played_cards.items():
+                print(card)
+            self.rules.canPlay(prepared_cards, visible_cards, player_index, self.round)
             for key, card_group in prepared_cards.items():
                 for card in card_group:
                     self.hand_cards.remove(card)
-                    # 19oct - don't think liverpool really uses played_cards other than in my print statement...
                     self.played_cards.setdefault(key, []).append(card)
-                    # todo:  Need to replace local record of played_cards with visible cards.
-                    # This will have ripple effects in rules when merging played cards with visible cards.
-                #TODO: debug THE NEXT 2 LINES!!!
-                #  self.played_cards = visible_card[key0][key1]
-                # self.played_cards.setdefault(key[1], []).append(card)
-        print('at line 108 in clientState, played_cards: ')
-        print(self.played_cards)
+                    # todo: need to sort cards here -- have to figure out how to designate wilds nominal value.
+                    # if its in the middle that's easy but Aces and wilds need to be set high or low.
+                    # can do that in a separate method...
+            # unlike HandAndFoot, self.played_cards includes cards played by everyone.
+        # todo: debug- this might be - print(self.played_cards)
 
     def getValidKeys(self, card):
         """Get the keys that this card can be prepared with"""

--- a/source/client/ClientState.py
+++ b/source/client/ClientState.py
@@ -78,7 +78,6 @@ class ClientState:
         """Move cards from hand to board"""
 
         # First check that all the cards are in your hand.
-        visible_cards = [{}]
         tempHand = [x for x in self.hand_cards]
         try:
             for card_group in prepared_cards.values():
@@ -86,7 +85,7 @@ class ClientState:
                     tempHand.remove(card)
         except ValueError:
             raise Exception("Attempted to play cards that are not in your hand")
-        # Check ruleset to determine whether self.played_cards = visible cards or cards that player played.
+        # Check ruleset to determine whether self.played_cards = all visible cards or cards that this client played.
         # todo: Create rule:  Shared_Board == True or False, it would be False for HandAndFoot, Canasta, etc...
         # but True for Liverpool and other Rummy games.
         if self.ruleset == 'HandAndFoot':
@@ -102,6 +101,7 @@ class ClientState:
             # Played cards are in visible_scards, which is obtained
             # from controller, and contains serialized cards.
             # To reduce computations, don't deserialize them until click on play cards button.
+            visible_cards = [{}]
             if self.first_play_this_turn:
                 visible_cards[0] = {key: [scard.deserialize() for scard in scard_group] for (key, scard_group) in
                                    visible_scards[0].items()}

--- a/source/client/ClientState.py
+++ b/source/client/ClientState.py
@@ -67,7 +67,6 @@ class ClientState:
         self.played_cards = {}
         self.went_out = False
         self.discard_info = [None, 0]
-        self.first_play_this_turn = True
 
     def newCards(self, card_list):
         """Update the cards in hand"""
@@ -102,27 +101,36 @@ class ClientState:
             # from controller, and contains serialized cards.
             # To reduce computations, don't deserialize them until click on play cards button.
             visible_cards = [{}]
-            if self.first_play_this_turn:
-                visible_cards[0] = {key: [scard.deserialize() for scard in scard_group] for (key, scard_group) in
-                                   visible_scards[0].items()}
-                print("visible_cards[0]: ")
-                for key, card in visible_cards[0].items():
-                    print(card)
-                self.first_play_this_turn = False
+            print('in ClientState, line 104')
+            for key, scard_group in visible_scards[0].items():
+                card_group=[]
+                for scard in scard_group:
+                    # card = scard.deserialize()
+                    card = Card(scard[0], scard[1], scard[2])
+                    # card = 'debugging'
+                    print(scard)
+                    card_group.append(card)
+                visible_cards[0][key]=card_group
+                print(visible_cards)
+
+            #visible_cards[0] = {key: [scard.deserialize() for scard in scard_group] for (key, scard_group) in
+            #                    visible_scards[0].items()}
             self.played_cards = visible_cards[0]  # in Liverpool all players' cards are included.
-            print("played_cards: ")
-            for key, card in self.played_cards.items():
-                print(card)
+            print("line 108 in ClientState.py, played_cards: ")
+            for key, card_group in self.played_cards.items():
+                for card in card_group:
+                    print(card)
             self.rules.canPlay(prepared_cards, visible_cards, player_index, self.round)
+            print("line 112 in ClientState.py, prepared cards: ")
             for key, card_group in prepared_cards.items():
                 for card in card_group:
                     self.hand_cards.remove(card)
                     self.played_cards.setdefault(key, []).append(card)
-                    # todo: need to sort cards here -- have to figure out how to designate wilds nominal value.
+                    # todo: need to sort cards here (or in Liverpool.;py)
+                    #  -- have to figure out how to designate wilds nominal value.
                     # if its in the middle that's easy but Aces and wilds need to be set high or low.
                     # can do that in a separate method...
             # unlike HandAndFoot, self.played_cards includes cards played by everyone.
-        # todo: debug- this might be - print(self.played_cards)
 
     def getValidKeys(self, card):
         """Get the keys that this card can be prepared with"""

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -23,6 +23,7 @@ class Controller(ConnectionListener):
         # needed for Liverpool:
         self.Meld_Threshold = self._state.rules.Meld_Threshold
         self.player_index = 0
+        self.visible_scards = [{}] # in Liverpool both HandView and TableView use data:visible cards.
 
     ### Player Actions ###
     def setName(self):
@@ -157,10 +158,12 @@ class Controller(ConnectionListener):
         """
         wilds_in_run = [] # this will be empty for sets and valid numbers for runs.
         sets_runs = self.Meld_Threshold[self._state.round]
+        '''
         if assigned_key[1] < sets_runs[0]:
             print('this should be a set')
         else:
             print('this should be a run')
+        '''
         for wrappedcard in selected_cards:
             card = wrappedcard.card
             self.prepareCard(assigned_key, card)
@@ -182,14 +185,15 @@ class Controller(ConnectionListener):
         self.prepared_cards = {}
         self.note = "You have no cards prepared to play"
 
-    def play(self, player_index=0, visible_cards=[{}]):
-        """Send the server the current set of visible cards"""
-        # player_index and visible_cards needed for liverpool rules checking.
+    def play(self, player_index=0, visible_scards=[{}]):
+        """Send the server the current set of played cards"""
+        # player_index and visible_scards needed for liverpool rules checking.
+        #
         if self._state.turn_phase != Turn_Phases[3]:
             self.note = "You can only play on your turn after you draw"
             return
         try:
-            self._state.playCards(self.prepared_cards, player_index, visible_cards)
+            self._state.playCards(self.prepared_cards, player_index, visible_scards)
             self.clearPreparedCards()
             self.handleEmptyHand(False)
             self.sendPublicInfo()
@@ -295,6 +299,15 @@ class Controller(ConnectionListener):
             return
         self._state.turn_phase = Turn_Phases[1]
         self.note = "Your turn has started. You may draw or attempt to pick up the pile"
+        #
+        # if playing with a shared board, then need to update played cards played.
+        if self._state.rules == 'Liverpool':
+            _state.first_play_this_turn = True  # must serialize visible_cards one time at beginning of turn.
+            # todo: get rid of _state.first_play_this_turn and perform serializaiton below.
+            # todo: have Network_startTurn send visible_cards for previous player's turn.
+            # send played_cards back to server, so that visible_cards[active player] is up to date.
+            _state.played_cards = visible_cards[0]  # in Liverpool all players' cards are included.
+
         self.sendPublicInfo() #Let everyone know its your turn.
 
     def Network_newCards(self, data):
@@ -310,7 +323,7 @@ class Controller(ConnectionListener):
         self._state.round = data["round"]
         self._state.reset()
         hand_list = [[Card.deserialize(c) for c in hand] for hand in data["hands"]]
-        #TODO: we want to allow the player to choose the order of the hands eventually
+        #TODO: in HandAndFoot we want to allow the player to choose the order of the hands eventually
         self._state.dealtHands(hand_list)
         self.sendPublicInfo() #More cards in hand now, need to update public information
 

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -306,7 +306,10 @@ class Controller(ConnectionListener):
             # todo: get rid of _state.first_play_this_turn and perform serializaiton below.
             # todo: have Network_startTurn send visible_cards for previous player's turn.
             # send played_cards back to server, so that visible_cards[active player] is up to date.
-            _state.played_cards = visible_cards[0]  # in Liverpool all players' cards are included.
+            _state.played_cards = visible_scards[0]  # in Liverpool all players' cards are included.
+            print('at line 310 in controller.py')
+            for key, vc in _state.played_cards():
+                print(vc)
 
         self.sendPublicInfo() #Let everyone know its your turn.
 

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -77,12 +77,10 @@ class HandView:
                               'When ready to start playing click on the YES button on the lower right.']
         self.RuleSetsButtons.CreateButtons(self)
 
-    def update(self, player_index=0, num_players=1, visible_cards = []):
+    def update(self, player_index=0, num_players=1, visible_scards = []):
         """This updates the view of the hand, between rounds it displays a message. """
 
-        # player_index and num_players needed for Liverpool but not HandAndFoot.
-        self.visible_cards = visible_cards
-        # this is a list (one per player) of dictionaries (one key per player button)
+        self.visible_scards = visible_scards
         self.player_index = player_index
         self.num_players = num_players
         if self.controller._state.round == -1:

--- a/source/client/LiverpoolButtons.py
+++ b/source/client/LiverpoolButtons.py
@@ -164,7 +164,7 @@ def ClickedButton(hand_view, pos):
         )
         hand_view.hand_info = HandManagement.RefreshXY(hand_view, hand_view.hand_info)
     elif hand_view.play_prepared_cards_btn.isOver(pos):
-        hand_view.controller.play(hand_view.player_index, hand_view.visible_cards)
+        hand_view.controller.play(hand_view.player_index, hand_view.visible_scards)
     elif hand_view.clear_prepared_cards_btn.isOver(pos):
         hand_view.controller.clearPreparedCards()
         hand_view.hand_info = HandManagement.ClearPreparedCardsInHandView(hand_view.hand_info)

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -44,7 +44,9 @@ class TableView(ConnectionListener):
         if self.ruleset == 'HandAndFoot':
             self.compressSets(self.visible_scards)
         elif self.ruleset == 'Liverpool':
-            #todo: debug - print(self.visible_scards)
+            #todo: debug -
+            print('line 48 in TableView')
+            print(self.visible_scards)
             self.compressGroups(self.visible_scards)
         num_players = len(self.player_names)
         # currently set-up with one player per column. May need to change that for more players.
@@ -140,18 +142,22 @@ class TableView(ConnectionListener):
         # played with key =(player, group) tuple.  Cards are sorted with wilds in runs appearing where the
         # card they represent would have appeared.
         #
-        # debug - print(v_cards)
         i_num_sets = int(self.Meld_Threshold[self.round_index][0])
         self.compressed_info = {}
-        for player_name in self.player_names:
-            self.compressed_info[player_name]=[]
         i_tot = len(self.player_names)
+        for idx in range(i_tot):
+            player_name = self.player_names[idx]
+            print(player_name)
+            self.compressed_info[player_name] = {}
+            print(self.compressed_info)
         #  for each key need to gather s_cards from all players (all idx).  s_card=card.serialize
         for idx in range(i_tot):
             summary = {}
             key_player = self.player_names[idx]
+            print('line 153 in tableview')
+            print(v_cards)
             # v_cards has different format when Shared_Baord==True (i.e. in Liverpool).
-            # it's [] until connected to the server, and then it's [{dictionary containing info on entire board}]
+            # it's [] until connected to the server, and there it's [{dictionary containing info on entire board}]
             if len(v_cards) > 0:
                 all_visible_one_dictionary = v_cards[0]
                 for key, card_group in all_visible_one_dictionary.items():

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -21,11 +21,10 @@ class TableView(ConnectionListener):
         self.ruleset = ruleset
         print('in Tableview: ruleset '+ self.ruleset)
         self.player_names = []
-        self.visible_cards = []
+        self.visible_scards = []        # contains list of serialized cards (from server)
         self.hand_status = []
         self.compressed_info = {}
-        # self.this_player_index = -1   # code review note -- this variable needed for Liverpool
-        # todo: check if still need variable above.
+        # self.this_player_index = -1   # code review note --is this variable needed for Liverpool?
         if self.ruleset == 'Liverpool':
             self.Meld_Threshold = Meld_Threshold_LP
             self.wild_numbers = wild_numbers_LP
@@ -34,7 +33,6 @@ class TableView(ConnectionListener):
         elif self.ruleset == 'HandAndFoot':
             self.Meld_Threshold = Meld_Threshold_HF
             self.wild_numbers = wild_numbers_HF
-            print('thinks ruleset is HandAndFoot')
         else:
             print(self.ruleset + ' is not supported')
         self.playerByPlayer(0)
@@ -44,9 +42,10 @@ class TableView(ConnectionListener):
         self.round_index = round_index
         # Loop through players and display visible cards associated with each players' melded groups.
         if self.ruleset == 'HandAndFoot':
-            self.compressSets(self.visible_cards)
+            self.compressSets(self.visible_scards)
         elif self.ruleset == 'Liverpool':
-            self.compressGroups(self.visible_cards)
+            #todo: debug - print(self.visible_scards)
+            self.compressGroups(self.visible_scards)
         num_players = len(self.player_names)
         # currently set-up with one player per column. May need to change that for more players.
         if num_players > 1:
@@ -137,69 +136,61 @@ class TableView(ConnectionListener):
 
         # In Liverpool:
         # visible cards structure:
-        # a list of dictionaries where each entry in list corresponds to dictionary of serialized cards
-        # played by THAT player with key =(player, group) tuple.
-        # This is the same as the structure used for HandAndFoot EXCEPT the keys are different.
-        # Note this makes compressGroups more complex than compressSets used in HandAndFoot.
-        # It simplifies key structure enormously and avoids making server game specific (beyond Ruleset).
-        #  BUT HAS unintentional side effects.
-        #  - if a player drops out his plays on other groups will disappear.
-        # AND round should probably end as any runs they've contributed to might no longer work...
-        # ---just tested this with 2 players, player 1 had just melded and played on both boards.
-        # when player 1 dropped out ALL cards disappeared (not just player 1's)
-        # --- repeated test but had player 2 drop out.  In this case player 2's cards disappeared.
+        # a list containing zero or 1 dictionary where each entry in dictionary is a list of serialized cards
+        # played with key =(player, group) tuple.  Cards are sorted with wilds in runs appearing where the
+        # card they represent would have appeared.
         #
-        # todo: reconsider this structure.  Also - with this structure you have can't preserve what spot jokers have in
-        # runs.  If runs are kept together than can use order of cards to preserve values of runs.
-        #
-        i_mt = int(self.Meld_Threshold[self.round_index][0])
+        # debug - print(v_cards)
+        i_num_sets = int(self.Meld_Threshold[self.round_index][0])
         self.compressed_info = {}
         for player_name in self.player_names:
             self.compressed_info[player_name]=[]
-        all_visible_one_dictionary = {}
-        i_tot = len(v_cards)
+        i_tot = len(self.player_names)
         #  for each key need to gather s_cards from all players (all idx).  s_card=card.serialize
-        for idx in range(i_tot):
-            temp_dictionary_v = v_cards[idx]
-            temp_dictionary = all_visible_one_dictionary
-            all_visible_one_dictionary = (combineCardDicts(temp_dictionary, temp_dictionary_v))
         for idx in range(i_tot):
             summary = {}
             key_player = self.player_names[idx]
-            for key, card_group in all_visible_one_dictionary.items():
-                text = ''
-                if key[0] == idx:
-                    if key[1] < i_mt:
-                        # this is a set
-                        card_numbers = []
-                        for s_card in card_group:
-                            if not s_card[0] in self.wild_numbers:
-                                card_numbers.append(s_card[0])
-                        unique_numbers = list(set(card_numbers))
-                        if len(unique_numbers) > 0:
-                            unique_number = int(unique_numbers[0])
-                        else:
-                            unique_number = 666 # this should never happen.
-                        text = 'SET of ' + str(unique_number) + "'s: "
-                        for s_card in card_group:
-                            if not s_card[0] in self.wild_numbers:
-                                text = text + str(s_card[1]) +  ','
+            # v_cards has different format when Shared_Baord==True (i.e. in Liverpool).
+            # it's [] until connected to the server, and then it's [{dictionary containing info on entire board}]
+            if len(v_cards) > 0:
+                all_visible_one_dictionary = v_cards[0]
+                for key, card_group in all_visible_one_dictionary.items():
+                    text = ''
+                    if key[0] == idx:
+                        if key[1] < i_num_sets:
+                            # this is a set
+                            card_numbers = []
+                            for s_card in card_group:
+                                if not s_card[0] in self.wild_numbers:
+                                    card_numbers.append(s_card[0])
+                            unique_numbers = list(set(card_numbers))
+                            if len(unique_numbers) > 0:
+                                unique_number = int(unique_numbers[0])
                             else:
-                                text = text + 'Wild' + ','
-                    else:
-                        # rewrite stuff below with structure more like what's used above.
-                        this_run = card_group
-                        l_this_run = len(this_run)
-                        if l_this_run > 0:
-                            idx_c = 0
-                            while this_run[idx_c] in self.wild_numbers and idx_c < l_this_run:
-                                idx_c = idx_c + 1
-                            card_suit = str(this_run[idx_c][1])
-                            text = 'Run in ' + card_suit + ": "
-                            for idx_c in range(l_this_run):
-                                text = text + str(this_run[idx_c][0]) + ','
-                        #todo: replace text above with something prettier.
-                    summary[key[1]] = text
+                                # this should never happen.
+                                unique_number = 666
+                                print('bug in TableView')
+                            text = 'SET of ' + str(unique_number) + "'s: "
+                            for s_card in card_group:
+                                if not s_card[0] in self.wild_numbers:
+                                    text = text + str(s_card[1]) +  ','
+                                else:
+                                    text = text + 'Wild' + ','
+                        else:
+                            # todo: rewrite stuff below with structure more like what's used above.
+                            # this is a run
+                            this_run = card_group
+                            l_this_run = len(this_run)
+                            if l_this_run > 0:
+                                idx_c = 0
+                                while this_run[idx_c] in self.wild_numbers and idx_c < l_this_run:
+                                    idx_c = idx_c + 1
+                                card_suit = str(this_run[idx_c][1])
+                                text = 'Run in ' + card_suit + ": "
+                                for idx_c in range(l_this_run):
+                                    text = text + str(this_run[idx_c][0]) + ','
+                            #todo: replace text above with something prettier.
+                        summary[key[1]] = text
                 self.compressed_info[key_player] = summary
 
     def display_melded_summary_HF(self, screen_loc_info, melded_summary):
@@ -266,7 +257,7 @@ class TableView(ConnectionListener):
            'hand_status': [['inactive', 12, 1], [True, 14, 1]]}
         where 'inactive' is an example of a play state (possible states: 'inactive', 'draw', 'forcedAction', 'play' '''
         self.player_names = data["player_names"]
-        self.visible_cards = data["visible_cards"]
+        self.visible_scards = data["visible_cards"]
         self.hand_status = data["hand_status"]
         # todo: do I need next line?
         self.playerByPlayer(0)

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -139,10 +139,19 @@ class TableView(ConnectionListener):
         # visible cards structure:
         # a list of dictionaries where each entry in list corresponds to dictionary of serialized cards
         # played by THAT player with key =(player, group) tuple.
-        # Note this makes compressGroups more complex than complessSets used in HandAndFoot.
+        # This is the same as the structure used for HandAndFoot EXCEPT the keys are different.
+        # Note this makes compressGroups more complex than compressSets used in HandAndFoot.
         # It simplifies key structure enormously and avoids making server game specific (beyond Ruleset).
-        # Probable unintentional side effect:
-        #   -- if a player drops out his plays on other groups will disappear.
+        #  BUT HAS unintentional side effects.
+        #  - if a player drops out his plays on other groups will disappear.
+        # AND round should probably end as any runs they've contributed to might no longer work...
+        # ---just tested this with 2 players, player 1 had just melded and played on both boards.
+        # when player 1 dropped out ALL cards disappeared (not just player 1's)
+        # --- repeated test but had player 2 drop out.  In this case player 2's cards disappeared.
+        #
+        # todo: reconsider this structure.  Also - with this structure you have can't preserve what spot jokers have in
+        # runs.  If runs are kept together than can use order of cards to preserve values of runs.
+        #
         i_mt = int(self.Meld_Threshold[self.round_index][0])
         self.compressed_info = {}
         for player_name in self.player_names:

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -28,8 +28,6 @@ class TableView(ConnectionListener):
         if self.ruleset == 'Liverpool':
             self.Meld_Threshold = Meld_Threshold_LP
             self.wild_numbers = wild_numbers_LP
-            print(self.Meld_Threshold)
-            print(self.wild_numbers)
         elif self.ruleset == 'HandAndFoot':
             self.Meld_Threshold = Meld_Threshold_HF
             self.wild_numbers = wild_numbers_HF
@@ -44,9 +42,6 @@ class TableView(ConnectionListener):
         if self.ruleset == 'HandAndFoot':
             self.compressSets(self.visible_scards)
         elif self.ruleset == 'Liverpool':
-            #todo: debug -
-            print('line 48 in TableView')
-            print(self.visible_scards)
             self.compressGroups(self.visible_scards)
         num_players = len(self.player_names)
         # currently set-up with one player per column. May need to change that for more players.
@@ -113,14 +108,14 @@ class TableView(ConnectionListener):
             bk_grd_rect = (bk_grd_rect[0] + players_sp_w, bk_grd_rect[1], bk_grd_rect[2], bk_grd_rect[3])
             color_index = (color_index + 1) % len(UIC.table_grid_colors)
 
-    def compressSets(self, v_cards):
+    def compressSets(self, v_scards):
         """ HandAndFoot specific: Don't have space to display every card. Summarize sets of cards here. """
 
         self.compressed_info = {}
-        for idx in range(len(v_cards)):
+        for idx in range(len(v_scards)):
             summary = {}
             key_player = self.player_names[idx]
-            melded = dict(v_cards[idx])
+            melded = dict(v_scards[idx])
             for key in melded:
                 set = melded[key]
                 length_set = len(set)
@@ -133,7 +128,7 @@ class TableView(ConnectionListener):
                     summary[key] = (length_set, (length_set - wild_count), wild_count)
             self.compressed_info[key_player] = summary
 
-    def compressGroups(self, v_cards):
+    def compressGroups(self, v_scards):
         """ Liverpool specific: Don't have space to display every card. Summarize groups of cards here. """
 
         # In Liverpool:
@@ -145,21 +140,14 @@ class TableView(ConnectionListener):
         i_num_sets = int(self.Meld_Threshold[self.round_index][0])
         self.compressed_info = {}
         i_tot = len(self.player_names)
-        for idx in range(i_tot):
-            player_name = self.player_names[idx]
-            print(player_name)
+        for player_name in self.player_names:
             self.compressed_info[player_name] = {}
-            print(self.compressed_info)
         #  for each key need to gather s_cards from all players (all idx).  s_card=card.serialize
         for idx in range(i_tot):
             summary = {}
             key_player = self.player_names[idx]
-            print('line 153 in tableview')
-            print(v_cards)
-            # v_cards has different format when Shared_Baord==True (i.e. in Liverpool).
-            # it's [] until connected to the server, and there it's [{dictionary containing info on entire board}]
-            if len(v_cards) > 0:
-                all_visible_one_dictionary = v_cards[0]
+            if len(v_scards) > 0:
+                all_visible_one_dictionary = v_scards[0]
                 for key, card_group in all_visible_one_dictionary.items():
                     text = ''
                     if key[0] == idx:

--- a/source/common/HandAndFoot.py
+++ b/source/common/HandAndFoot.py
@@ -10,6 +10,7 @@ import math
 
 Game_Name = "Hand and Foot"
 
+# In GamerServer.py Shared_Board = False for ruleset = HandAndFoot
 Draw_Size = 2
 Pickup_Size = 8
 Discard_Size = 1

--- a/source/common/Liverpool.py
+++ b/source/common/Liverpool.py
@@ -46,12 +46,10 @@ def isWild(card):
         return False
 
 
-# todo below is for checking on sets, but for liverpool will also have runs.
+# todo: below is for checking on sets in HandAndFoot (not used for Liverpool sets)
+#  for Liverpool will need this for runs.
 # player will probably have to state which set a card goes with, so this may be extraneous.
-#  FOR LIVERPOOL KEY SHOULD NOT BE RANK, BUT POSSIBLE VALUE GIVEN
-#  INDEX OF BUTTON USED TO PREPARE CARD.  FOR SETS THIS WILL BE RANK CARD.NUMBER FOR
-#  EXISTING SET, AND FOR RUN IT WILL BE PLACE IN
-#  RUN=(NUMBER BETWEEN MIN-1 AND MAX+1) THAT HASN'T BEEN TAKEN.
+#  In Liverpool wild will need to be (NUMBER BETWEEN MIN-1 AND MAX+1) THAT HASN'T BEEN TAKEN.
 def getKeyOptions(card):
     """returns the possible keys for the groups the card can go in"""
     if not isWild(card):
@@ -70,6 +68,7 @@ def canPlayGroup(key, card_group, this_round=0):
         return True  # Need to allow empty groups to be "played" due to side-effects of how we combined dictionaries
     if key[1] < Meld_Threshold[this_round][0]:   # then this is a set.
         #todo: fix required length of set!
+
         # check if this is a valid set.
         if len(card_group) < 1:
             raise Exception("Too few cards in set - minimum is 1")
@@ -89,13 +88,25 @@ def canPlayGroup(key, card_group, this_round=0):
             text = "Too many wilds in set of " + str(unique_number) + "'s"
             raise Exception(text)
     else:
-        print('in canPlayGroup, not checking runs')
+        print('in canPlayGroup, now checking runs')
         print(key)
-    '''
         # check that this is a valid run.
-        if len(card_group) < 4:
-            raise Exception("Too few cards in run - minimum is 4")
-    typeDiff = 0
+        if len(card_group) < 2:
+            #todo:  for debugging only require  < 2, will need to change that to 4 later.
+            raise Exception("Too few cards in run - minimum is 2 (for now) 4 (final version)")
+        suits_in_run = []
+        numbers_in_run = []
+        for card in card_group:
+            if not isWild(card):
+                suits_in_run.append(card.suit)
+                numbers_in_run.append(card.number)
+        num_naturals = len(suits_in_run)
+        unique_suits = list(set(card_numbers))
+        if len(unique_suits) > 1:
+            raise Exception("Cards in a run must all have the same suit (except wilds).")
+        numbers_in_run.sort # stopped here at 6:30 on 10/19.
+
+    '''
     for card in card_group:
         if isWild(card):
             typeDiff -= 1

--- a/source/common/Liverpool.py
+++ b/source/common/Liverpool.py
@@ -145,28 +145,28 @@ def canPickupPile(top_card, prepared_cards, played_cards, round_index):
 
 def canPlay(prepared_cards, visible_cards, player_index, round_index):
     """Confirms if playing the selected cards is legal"""
-    # Has player already melded -- if so visible_cards[player_index] will NOT be empty and
-    #
+
+    # what groups have already been played?
     played_groups = []
-    for key, s_cards in visible_cards[0].items():
-        if len(s_cards) > 0:
+    for key, cards in visible_cards[0].items():
+        if len(cards) > 0:
             played_groups.append(key)
+    print('line 154 in Liverpool.py, canPlay method - played_groups:')
+    print(played_groups)
+    # does player attempt to play on another player's groups before that player has melded ?
+    for key, cards in prepared_cards.items():
+        if len(cards) > 0:
+            group_key = key
+            if not group_key[0] == player_index and group_key not in played_groups:
+                raise Exception("You are not allowed to begin another player's sets or runs.")
+                print('line 162 of Liverpool.py, group_key')
+                print(group_key)
+    # Has player already melded? -- if so visible_cards[player_index] will NOT be empty.
     if (player_index,0) not in played_groups:
         # if a player has already melded than (player_index,0) will have dictionary entry with cards.
         return canMeld(prepared_cards, round_index, player_index)
-    all_visible_one_dictionary = {}
-    for temp_dict_v_s in visible_cards:
-        # temp_dict_v_s is a dictionary with keys = tuple and elements= list of serialized cards from one player.
-        # temp_dictionary_v is same dictionary EXCEPT the serialized cards have been deserialized.
-        temp_dictionary_v = {}
-        for key, s_cards in temp_dict_v_s.items():
-            card_list = [Card.deserialize(c) for c in s_cards]
-            temp_dictionary_v[key] = card_list
-        # gathering all played cards from all players into single dictionary.
-        temp_dictionary = all_visible_one_dictionary
-        all_visible_one_dictionary = (combineCardDicts(temp_dictionary, temp_dictionary_v))
     # gathering all played and prepared_cards into single dictionary (needed for rule checking).
-    combined_cards = combineCardDicts(all_visible_one_dictionary, prepared_cards)
+    combined_cards = combineCardDicts(visible_cards[0], prepared_cards)
     for key, card_group in combined_cards.items():
         canPlayGroup(key, card_group, round_index)
     return True

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -22,7 +22,7 @@ class GameServer(Server, ServerState):
         # todo: but might not need it (jury still out).
         if ruleset == "Liverpool":
             self.Shared_Board = True
-            #  self.v_cards = [{}]
+            self.visible_cards_now = {}
         else:
             self.Shared_Board = False
         print('Server launched')
@@ -172,18 +172,45 @@ class GameServer(Server, ServerState):
 
         if self.Shared_Board:
             # Liverpool -- each player can play on any players cards.
-            debuggingFlag = False
+            debuggingFlag = True
             if debuggingFlag:
                 print('at line 173')
                 print(self.players)
                 self.v_cards = [p.visible_cards for p in self.players]
+                if len(self.v_cards) == 0:
+                    self.v_cards = [{}]
+                print('at line 180')
                 print(self.v_cards)
+                # brainstorm -- set self.visible_cards_now to the element in v_cards with the most cards.
+                max_len = -1
+                self.visible_cards_now = {}
+                print('at line 187 in gameserver')
+                for v_cards_dict in self.v_cards:
+                    print('line 188 in gameserver')
+                    print(v_cards_dict)
+                    temp_length = 0
+                    for key, scard_group in v_cards_dict.items():
+                        print(key)
+                        print(scard_group)
+                        print(len(scard_group))
+                        temp_length = temp_length + len(scard_group)
+                        print(temp_length)
+                    if temp_length > max_len:
+                        self.visible_cards_now = v_cards_dict
+                        print('at line 190 in gameserver.py')
+                        print(temp_length)
+                        print(self.visible_cards_now)
+                self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": [self.visible_cards_now],"hand_status": [p.hand_status for p in self.players]})
+
+                '''
+                earlier attempt --
                 #todo: double check that this doesn't wipe out the last players plays.
                 # There should be delay due to discard.
                 # visible_cards_now = self.v_cards[self.turn_index]
                 if len(self.v_cards) > 0:
                     visible_cards_now = self.v_cards[0]
                     self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": visible_cards_now,"hand_status": [p.hand_status for p in self.players]})
+                '''
             else:
                 self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": [p.visible_cards for p in self.players],"hand_status": [p.hand_status for p in self.players]})
         else:

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -4,8 +4,6 @@ from server.ServerState import ServerState
 from PodSixNet.Server import Server
 from PodSixNet.Channel import Channel
 
-from time import sleep          # only used in Liverpool draft.
-
 class GameServer(Server, ServerState):
     channelClass = PlayerChannel
 
@@ -19,7 +17,6 @@ class GameServer(Server, ServerState):
         self.in_round = False
         self.game_over = False
         # todo: Shared_Board should probably be set in Ruleset.py, not here.
-        # todo: but might not need it (jury still out).
         if ruleset == "Liverpool":
             self.Shared_Board = True
             self.visible_cards_now = {}
@@ -92,63 +89,10 @@ class GameServer(Server, ServerState):
 
     def nextTurn(self):
         """Advance to the next turn"""
-
-        '''
-        if self.Shared_Board:
-            print('in GameServer.nexTurn method--- have bug with how its written below.')
-            print('possible fix would be to use combineDict method to take union of groups in dicionaries....')
-            print('will need to go through step to make certain that same card doesnt appear 2x in dictionary.')
-            print('first make certain its not another bug causing played cards to be lost.')
-            print('next player is not getting self.cards_on_board!!!')
-            print(self.players[self.turn_index])
-            # with a shared board every player sees the same board.
-            #todo: remove debugging print statements
-            print(self.turn_index)
-            print('self.players[self.turn_index].visible_cards')
-            print(self.players[self.turn_index].visible_cards)
-            print(self.players[self.turn_index])
-            self.cards_on_board = self.players[self.turn_index].visible_cards
-            # above are debugging print statements
-            #
-            # used for games with Shared_Board=True, need to update visible cards immediately, before next turn begins.
-            # todo: fix bug --
-            # Observed with 2 players :
-            # played cards are disappearing when discard button is hit.
-            # they reappear the next time it is that player's turn.
-            # Next 2 lines are effort to fix bug, but they didn't work.
-            self.players[self.turn_index].visible_cards = self.cards_on_board # this probably is done.
-            self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players], "visible_cards": [self.cards_on_board], "hand_status": [p.hand_status for p in self.players]})
-            print('in GameServer, line 121, cards_on_board:')
-            print( [self.cards_on_board])
-            #
-        '''
-        # note for review: want to send visible_cards one more time before next player starts, so there
-        # is time for the active players played_cards variable to be updated, and transmitted back to
-        # server.
-        # todo: double check that this doesn't wipe out the last players plays.
-
-        '''
-        if self.Shared_Board:
-            visible_cards_now = v_cards[self.turn_index]
-            sleep(1.0)
-            # todo:  making sure that visible cards is updated before broadcast one more time before
-            #  switching turns.  Find a better way.
-            self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],
-                                 "visible_cards": [visible_cards_now],
-                                 "hand_status": [p.hand_status for p in self.players]})
-        '''
         newIndex = (self.turn_index + 1) % len(self.players)
         self.turn_index = newIndex
         self.players[self.turn_index].Send({"action": "startTurn"})
-        '''if self.Shared_Board:
-            sleep(1.0)
-        '''
-        # prevent out of date version of visible cards from being broadcast.
-        #  Hopefully 1.0 sec is adequate time.
-        # todo: Come up with a better way then simply waiting to make certain that visible_cards
-        #  is accurately being updated.
-        #  todo: Note that this should not be hardcoded here, move to a more obvious location.
-        
+
     def Send_broadcast(self, data):
         """Send data to every connected player"""
         [p.Send(data) for p in self.players]
@@ -172,50 +116,26 @@ class GameServer(Server, ServerState):
 
         if self.Shared_Board:
             # Liverpool -- each player can play on any players cards.
-            debuggingFlag = True
-            if debuggingFlag:
-                print('at line 173')
-                print(self.players)
-                self.v_cards = [p.visible_cards for p in self.players]
-                if len(self.v_cards) == 0:
-                    self.v_cards = [{}]
-                print('at line 180')
-                print(self.v_cards)
-                # brainstorm -- set self.visible_cards_now to the element in v_cards with the most cards.
-                max_len = -1
-                self.visible_cards_now = {}
-                print('at line 187 in gameserver')
-                for v_cards_dict in self.v_cards:
-                    print('line 188 in gameserver')
-                    print(v_cards_dict)
-                    temp_length = 0
-                    for key, scard_group in v_cards_dict.items():
-                        print(key)
-                        print(scard_group)
-                        print(len(scard_group))
-                        temp_length = temp_length + len(scard_group)
-                        print(temp_length)
-                    if temp_length > max_len:
-                        self.visible_cards_now = v_cards_dict
-                        print('at line 190 in gameserver.py')
-                        print(temp_length)
-                        print(self.visible_cards_now)
-                self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": [self.visible_cards_now],"hand_status": [p.hand_status for p in self.players]})
-
-                '''
-                earlier attempt --
-                #todo: double check that this doesn't wipe out the last players plays.
-                # There should be delay due to discard.
-                # visible_cards_now = self.v_cards[self.turn_index]
-                if len(self.v_cards) > 0:
-                    visible_cards_now = self.v_cards[0]
-                    self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": visible_cards_now,"hand_status": [p.hand_status for p in self.players]})
-                '''
-            else:
-                self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": [p.visible_cards for p in self.players],"hand_status": [p.hand_status for p in self.players]})
+            self.v_cards = [p.visible_cards for p in self.players]
+            if len(self.v_cards) == 0:
+                self.v_cards = [{}]
+            # v_cards contains a dictionary from each player/client
+            # each dictionary contains all the played cards that player/client is aware of.
+            # set self.visible_cards_now to the dictionary in v_cards with the most cards.
+            max_len = -1
+            self.visible_cards_now = {}
+            for v_cards_dict in self.v_cards:
+                temp_length = 0
+                for key, scard_group in v_cards_dict.items():
+                    temp_length = temp_length + len(scard_group)
+                if temp_length > max_len:
+                    self.visible_cards_now = v_cards_dict
+                    max_len = temp_length
+            # Next line must be long (no line breaks) or it doesn't work properly.
+            self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players],"visible_cards": [self.visible_cards_now],"hand_status": [p.hand_status for p in self.players]})
         else:
             # HandAndFoot -- each player can only play on their own cards.
-            # discovered that this HAS to be strung out long or it doesn't work properly.
+            # Next line must be long (no line breaks) or it doesn't work properly.
             self.Send_broadcast({"action": "publicInfo", "player_names": [p.name for p in self.players], "visible_cards": [p.visible_cards for p in self.players], "hand_status": [p.hand_status for p in self.players]})
 
 

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -10,7 +10,7 @@ class PlayerChannel(Channel):
         """
         self.name = "guest"
         #visible cards and hand status are public info
-        self.visible_cards = {}
+        self.visible_cards = {}  # cards on board, in serialized format.
         self.hand_status = [] #order of information in this is specified by the ruleset
         self.scores = []
         self.ready = False #for consensus transitions
@@ -88,5 +88,6 @@ class PlayerChannel(Channel):
     def Network_publicInfo(self, data):
         """This is refreshed public information data from the client"""
         self.visible_cards = data["visible_cards"]
+
         self.hand_status = data["hand_status"]
         self._server.Send_publicInfo()


### PR DESCRIPTION
For Liverpool; Changed structure of visible_cards so that it is now a list containing a single dictionary.  That dictionary is the longest dictionary received from the player channels.  This allows you to preserve cards played by a player who later drops out. AND to preserve the ordering of runs, which should simplify assigning wilds.