### PR TITLE
playerLeftGame

### DIFF
--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -95,7 +95,6 @@ def RunClient():
             player_index = tableView.player_names.index(playername)
             visible_scards = tableView.visible_scards
             handView.update(player_index, len(tableView.player_names), visible_scards)
-            # todo: if player drops then set/run button locations need to be adjusted.
         else:
             handView.update()
         note = gameControl.note

--- a/source/client/LiverpoolButtons.py
+++ b/source/client/LiverpoolButtons.py
@@ -90,8 +90,7 @@ def ButtonDisplay(hand_view):
 
     # at beginning of round of Liverpool (or other shared_board game) create new buttons.
     # Review note - wait until all players hit OK else it crashes if you hit OK and then another player joins,
-    # because then you won't have buttons for that player.  Note if a player leaves mid round then the sets and runs
-    # that disappear are those of the player on the far right.
+    # because then you won't have buttons for that player.
     if hand_view.need_updated_buttons and not hand_view.controller._state.round == -1:
         hand_view.RuleSetsButtons.newRound(hand_view, hand_view.Meld_Threshold[hand_view.round_index])
         hand_view.need_updated_buttons = False

--- a/source/common/Liverpool.py
+++ b/source/common/Liverpool.py
@@ -65,7 +65,7 @@ def canPlayGroup(key, card_group, this_round):
     if key[1] < Meld_Threshold[this_round][0]:   # then this is a set.
         # check if this is a valid set.
         if len(card_group) < 3:
-            raise Exception("Too few cards in set - minimum is 1 (will change to 3 later)")
+            raise Exception("Too few cards in set - minimum is 3")
         # check that group contains only wilds and one card_number.
         card_numbers = []
         num_cards = len(card_group)


### PR DESCRIPTION
added method in HandView to handle moving buttons over when a player drops out of a game mid-round.   Buttons spaced appropriately and prepared cards are cleared.  Also moved call to "self.controller.resetProcessedCards(self.visible_scards)" into this method.